### PR TITLE
Add alias for deleting already merged branches automatically

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,3 +13,5 @@
 	ff = only
 [fetch]
   prune = true
+[alias]
+  pp = !git pull && git branch --merged | egrep -v '^\\*|master$|develop$'| xargs git branch -d

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,16 +1,16 @@
 [user]
-	email = g.pionelish30@gmail.com
-	name = pione30
+  email = g.pionelish30@gmail.com
+  name = pione30
 [core]
-	autocrlf = input
+  autocrlf = input
 [color]
-	ui = true
+  ui = true
 [push]
-	default = simple
+  default = simple
 [merge]
-	ff = false
+  ff = false
 [pull]
-	ff = only
+  ff = only
 [fetch]
   prune = true
 [alias]


### PR DESCRIPTION
`git branch --merged` displays already merged branches.
Add an alias `pp` which plays `git pull` and delete already merged branches automatically.