### PR TITLE
Not to run `git branch -d` if empty

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -14,4 +14,4 @@
 [fetch]
   prune = true
 [alias]
-  pp = !git pull && git branch --merged | egrep -v '^\\*|master$|develop$'| xargs git branch -d
+  pp = !git pull && git branch --merged | egrep -v '^\\*|master$|develop$'| xargs --no-run-if-empty git branch -d


### PR DESCRIPTION
Were no branches to be deleted `git pp` displays `fatal: branch name required`.
`xargs --no-run-if-empty` is the solution.