### PR TITLE
Disable <C-k> on VS Code Vim plugin

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -13,7 +13,10 @@
     "eslint.autoFixOnSave": true,
     "vetur.validation.template": false,
     "vim.easymotion": true,
-    "vim.handleKeys": { "<C-f>": false },
+    "vim.handleKeys": {
+        "<C-f>": false,
+        "<C-k>": false
+    },
     "vim.hlsearch": true,
     "vim.leader": " ",
     "vim.useSystemClipboard": true,


### PR DESCRIPTION
`<C-k>` is usually used to close folder on VS Code (Command + k for macOS, though.)