### PR TITLE
set true to editor.formatOnSave

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -49,6 +49,7 @@
     "ruby.useBundler": true,
     "ruby.useLanguageServer": true,
     "ruby.rubocop.useBundler": true,
-    "markdown.preview.fontSize": 15
+    "markdown.preview.fontSize": 15,
+    "editor.formatOnSave": true
 }
 


### PR DESCRIPTION
Mainly because [Rust (rls)](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) requires this for auto-formatting by `rustfmt`.