### PR TITLE
prefer check-for-staged-changes to check-for-changes

### DIFF
--- a/zsh.d/.zsh_prompt
+++ b/zsh.d/.zsh_prompt
@@ -1,7 +1,7 @@
 # PROMPT with vcs_info
 autoload -Uz vcs_info
 setopt prompt_subst
-zstyle ':vcs_info:git:*' check-for-changes true
+zstyle ':vcs_info:git:*' check-for-staged-changes true
 zstyle ':vcs_info:git:*' stagedstr "%F{yellow}+"
 zstyle ':vcs_info:git:*' unstagedstr "%F{red}*"
 zstyle ':vcs_info:*' formats "%F{magenta}%c%u%m(%b) %f"


### PR DESCRIPTION
`check-for-changes` checks the working tree if it has any unstaged changes, so this is significantly expensive function when the current repository is considerably big.
Instead I decided to use `check-for-staged-changes` which never checks the worktree files. I think that's some reasonable point of compromise...