### PR TITLE
"editor.formatOnSaveMode": "file" on rust specified settings

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -6,7 +6,8 @@
     "editor.tabSize": 2,
     "[rust]": {
         "editor.tabSize": 4,
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "editor.formatOnSaveMode": "file"
     },
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true


### PR DESCRIPTION
`"editor.formatOnSaveMode": "modifications"` has a conflict with auto-format of rust-analyzer.