### PR TITLE
Disable `diffEditor.ignoreTrimWhitespace`

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -73,4 +73,5 @@
     "terminal.integrated.defaultProfile.osx": "zsh",
     "terminal.integrated.drawBoldTextInBrightColors": false,
     "terminal.integrated.fontSize": 14,
+    "diffEditor.ignoreTrimWhitespace": false,
 }


### PR DESCRIPTION
I don't know when this setting dropped in, but it seems quite reasonable default.