### PR TITLE
Call `compinit` only if not `autoload`ed

### DIFF
--- a/zsh.d/.zsh_basic
+++ b/zsh.d/.zsh_basic
@@ -40,8 +40,10 @@ bindkey "^b" history-beginning-search-forward-end
 ########################################
 # completion
 #
-autoload -Uz compinit
-compinit
+if ! command -v compinit > /dev/null; then
+  autoload -Uz compinit
+  compinit
+fi
 
 # 補完で大文字にもマッチ
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'


### PR DESCRIPTION
`compinit` may be called inside the other scripts like version-manager initializations.
So in `.zsh_basic` we should call `compinit` only if it has not been `autoload`ed yet.